### PR TITLE
Saving reviews and stars

### DIFF
--- a/tp-frontend/nospeak-project/nospeak_client/src/styled-components/Body/MediaControlCard.jsx
+++ b/tp-frontend/nospeak-project/nospeak_client/src/styled-components/Body/MediaControlCard.jsx
@@ -35,15 +35,6 @@ export default function MediaControlCard({client, songs, setSongs, setDeleteAler
         });
       };
 
-    //   const handleReview = (songId, index) => {
-    //     const songToReview = songs[index];
-    //     setReviewAlertData({
-    //       songId: songToReview._id,
-    //       songTitle: songToReview.title,
-    //       indexToRemove: index,
-    //     });
-    //   };
-
     const fetchUserHistorial = () => {
         if (user && user.id) {
             client.get(`/api/historiales-usuario/${user.id}`)

--- a/tp-frontend/nospeak-project/nospeak_client/src/styled-components/Body/MediaControlCard.jsx
+++ b/tp-frontend/nospeak-project/nospeak_client/src/styled-components/Body/MediaControlCard.jsx
@@ -35,14 +35,14 @@ export default function MediaControlCard({client, songs, setSongs, setDeleteAler
         });
       };
 
-      const handleReview = (songId, index) => {
-        const songToReview = songs[index];
-        setReviewAlertData({
-          songId: songToReview._id,
-          songTitle: songToReview.title,
-          indexToRemove: index,
-        });
-      };
+    //   const handleReview = (songId, index) => {
+    //     const songToReview = songs[index];
+    //     setReviewAlertData({
+    //       songId: songToReview._id,
+    //       songTitle: songToReview.title,
+    //       indexToRemove: index,
+    //     });
+    //   };
 
     const fetchUserHistorial = () => {
         if (user && user.id) {
@@ -93,7 +93,22 @@ export default function MediaControlCard({client, songs, setSongs, setDeleteAler
             console.error('Error al actualizar el historial:', error);
         }
     };
-    
+    const handleReview = (songId, index, newRating) => {
+        const song = songs[index];
+        const updatedSongs = songs.map((s, i) => 
+          i === index ? {...s, userRating: newRating} : s
+        );
+        setSongs(updatedSongs);
+        
+        setReviewAlertData({
+          songId: songId,
+          songTitle: song.title,
+          indexToRemove: index,
+          currentRating: newRating,
+          reviewId: song.reviewId || '', 
+          currentReview: song.userReview || ''
+        });
+      };
     return (
         <>
             <TitleContainer>
@@ -123,18 +138,6 @@ export default function MediaControlCard({client, songs, setSongs, setDeleteAler
                                     <IconButton aria-label="delete" onClick={() => handleDelete(song._id, index)}>
                                         <StyledDeleteIcon sx={{ color: 'white' }} />
                                     </IconButton>)}
-                                    {/* <IconButton
-                                        aria-label="play/pause"
-                                        onClick={() => handleFavoriteClick(song._id)}
-                                    >
-                                        <StarIcon
-                                            sx={{
-                                                height: 35,
-                                                width: 35,
-                                                color: isSongInHistorial(song._id) ? '#FFA130' : 'white',
-                                            }}
-                                        />
-                                    </IconButton> */}
                                     {user.isAdmin && (
                                     <IconButton aria-label="edit">
                                         <Link to={{ pathname: `/song/${song._id}` }}>
@@ -143,18 +146,17 @@ export default function MediaControlCard({client, songs, setSongs, setDeleteAler
                                     </IconButton>
                                     )}
                                     <Rating
-                                            name="hover-feedback"
-                                            value={value}
-                                            precision={0.5}
-                                            onChange={(event, newValue) => {
-                                            setValue(newValue);
-                                            }}
-                                            onChangeActive={(event, newHover) => {
-                                            setHover(newHover);
-                                            }}
-                                            onClick={() => handleReview(song._id, index)}
-                                            emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
-                                        />
+                                    name={`rating-${song._id}`}
+                                    value={song.userRating || 0}
+                                    precision={0.5}
+                                    onChange={(event, newValue) => {
+                                        handleReview(song._id, index, newValue);
+                                    }}
+                                    onChangeActive={(event, newHover) => {
+                                        setHover(newHover);
+                                    }}
+                                    emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
+                                    />
                                         <CommentIcon
                                             sx={{
                                                 height: 25,


### PR DESCRIPTION
Added rating and reviews persistence in the db. Now they are stored locally and in the database.

- If a song already has a review from an user and the review OR rating it's updated, it sends a patch to the db and updates the db without having to create a new review.
- If the song didn't have any reviews from the user, it creates a review and it saves it.
- If the user changes paths, the song will remain with the latest rating until it's changed again. The same if the user logs out.